### PR TITLE
Add middleware to require login

### DIFF
--- a/houseoffun/houseoffun/middleware.py
+++ b/houseoffun/houseoffun/middleware.py
@@ -1,0 +1,33 @@
+from django.http import HttpResponseRedirect
+from django.conf import settings
+from re import compile
+
+EXEMPT_URLS = [compile(settings.LOGIN_URL.lstrip('/'))]
+if hasattr(settings, 'LOGIN_EXEMPT_URLS'):
+    EXEMPT_URLS += [compile(expr) for expr in settings.LOGIN_EXEMPT_URLS]
+    
+def LoginRequiredMiddleware(get_response):
+    """
+    Middleware that requires a user to be authenticated to view any page other
+    than LOGIN_URL. Exemptions to this requirement can optionally be specified
+    in settings via a list of regular expressions in LOGIN_EXEMPT_URLS (which
+    you can copy from your urls.py).
+    Requires authentication middleware and template context processors to be
+    loaded. You’ll get an error if they aren’t.
+    Taken from: https://python-programming.com/recipes/django-require-authentication-pages/#comment-791
+    """
+    
+    # One-time configuration and initialization.
+    def middleware(request):
+        # Code to be executed for each request before
+        # the view (and later middleware) are called.
+        response = get_response(request)
+        if not request.user.is_authenticated():
+            path = request.path_info.lstrip('/')
+            if not any(m.match(path) for m in EXEMPT_URLS):
+                return HttpResponseRedirect(settings.LOGIN_URL)
+        # Code to be executed for each request/response after
+        # the view is called.
+        return response
+    
+    return middleware

--- a/houseoffun/settings.py
+++ b/houseoffun/settings.py
@@ -52,6 +52,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'houseoffun.houseoffun.middleware.LoginRequiredMiddleware',
 ]
 
 ROOT_URLCONF = 'houseoffun.urls'
@@ -136,6 +137,11 @@ STATIC_URL = '/static/'
 ACCOUNT_ACTIVATION_DAYS = 7
 LOGIN_REDIRECT_URL = '/'
 SIMPLE_BACKEND_REDIRECT_URL = '/'
+LOGIN_EXEMPT_URLS = (
+    r'^accounts/register',
+    r'^accounts/login',
+    r'^accounts/password/reset',
+)
 
 # Email Settings
 EMAIL_BACKEND = 'django.core.mail.backends.filebased.EmailBackend'


### PR DESCRIPTION
Only pages accessible while logged out should be: login, registration,
and forgot password.